### PR TITLE
인스턴싱 구현

### DIFF
--- a/learnMetal_2/App/MetalViewDelegate.swift
+++ b/learnMetal_2/App/MetalViewDelegate.swift
@@ -22,6 +22,8 @@ class MetalViewDelegate : NSObject, MTKViewDelegate {
         self.commandQueue = self.device.makeCommandQueue()!
         super.init()
     
+        metalView.depthStencilPixelFormat = .depth32Float
+        
         buildSamplerState()
         buildDepthStencilState()
     }

--- a/learnMetal_2/Scenes/InstanceScene.swift
+++ b/learnMetal_2/Scenes/InstanceScene.swift
@@ -8,6 +8,9 @@ import SwiftUI
 import MetalKit
 
 class InstanceScene: Renderer {
+    
+    var generator = SeededGenerator(seed: 1234)
+    
     let device: MTLDevice
     let view: MTKView
     
@@ -44,9 +47,10 @@ class InstanceScene: Renderer {
         
         return texture
     }
+    
     private func buildOBJPipelineState(frag: String) -> MTLRenderPipelineState? {
         guard let library = device.makeDefaultLibrary(),
-              let vertexFunction = library.makeFunction(name: "vertex_shader"),
+              let vertexFunction = library.makeFunction(name: "instanced_vertex_shader"),
               let fragmentFunction = library.makeFunction(name: frag)
         else { return nil }
         
@@ -55,6 +59,7 @@ class InstanceScene: Renderer {
         pipelineDescriptor.vertexFunction = vertexFunction
         pipelineDescriptor.fragmentFunction = fragmentFunction
         pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+        pipelineDescriptor.depthAttachmentPixelFormat = .depth32Float
         
         let vertexDescriptor = buildVertexDescriptor()
         
@@ -68,6 +73,7 @@ class InstanceScene: Renderer {
             return nil
         }
     }
+    
     private func buildVertexDescriptor() -> MTLVertexDescriptor {
         let vertexDescriptor = MTLVertexDescriptor()
         
@@ -91,6 +97,7 @@ class InstanceScene: Renderer {
         
         return vertexDescriptor
     }
+    
     private func loadModel(device: MTLDevice, modelName: String) -> ([MDLMesh], [MTKMesh])? {
         guard let assetURL = Bundle.main.url(forResource: modelName, withExtension: "obj") else {
             fatalError("Asset \(modelName) dose not exist.")
@@ -141,35 +148,64 @@ class InstanceScene: Renderer {
         commandEncoder.setVertexBytes(&sceneConstants, length: MemoryLayout<SceneConstants>.stride,
                                       index: 2)
         
-        //MARK: 40 Ttouches
-        for _ in 0..<40 {
-                               
-            var sourceModelConstants = ModelConstants()
-                               
-            let ttouchScaleMatrix = matrix_float4x4(scaleX: Float(arc4random_uniform(5)), y: Float(arc4random_uniform(5)), z: Float(arc4random_uniform(5)))
-            let ttouchTranslationMatrix = matrix_float4x4(translationX: Float(arc4random_uniform(5))-2, y: Float(arc4random_uniform(5))-3, z: -5)
-            sourceModelConstants.modelViewMatrix = matrix_multiply(ttouchTranslationMatrix, ttouchScaleMatrix)
-            
-            commandEncoder.setVertexBytes(&sourceModelConstants, length: MemoryLayout<ModelConstants>.stride, index: 1)
-            
-            commandEncoder.setFragmentTexture(ttouchTexture, index: 0)
-            
-            guard let meshes = self.meshes?.1 as? [MTKMesh], meshes.count > 0 else { return }
-
-            for mesh in meshes {
-                let vertexBuffer = mesh.vertexBuffers[0]
-                commandEncoder.setVertexBuffer(vertexBuffer.buffer, offset: vertexBuffer.offset, index: 0)
-                for submesh in mesh.submeshes {
-                    commandEncoder.drawIndexedPrimitives(type: submesh.primitiveType,
-                                                         indexCount: submesh.indexCount,
-                                                         indexType: submesh.indexType,
-                                                         indexBuffer: submesh.indexBuffer.buffer,
-                                                         indexBufferOffset: submesh.indexBuffer.offset)
-                }
+        
+//        MARK: 40 Ttouches, Instancing, One Draw Call
+        var sourceModelConstantsArray = [ModelConstants](repeating: ModelConstants(), count: 40)
+        guard let meshes = self.meshes?.1 as? [MTKMesh], meshes.count > 0 else { return }
+        
+        for i in 0..<40 {
+            let ttouchScaleMatrix = matrix_float4x4(scaleX: Float(generator.next(upperBound: 5)), y: Float(generator.next(upperBound: 5)), z: Float(generator.next(upperBound: 5)))
+            let ttouchTranslationMatrix = matrix_float4x4(translationX: Float(generator.next(upperBound: 5))-2, y: Float(generator.next(upperBound: 5))-3, z: -5)
+            sourceModelConstantsArray[i].modelViewMatrix = matrix_multiply(ttouchTranslationMatrix, ttouchScaleMatrix)
+        }
+        
+        commandEncoder.setVertexBytes(&sourceModelConstantsArray, length: MemoryLayout<ModelConstants>.stride * sourceModelConstantsArray.count, index: 1)
+        commandEncoder.setFragmentTexture(ttouchTexture, index: 0)
+        
+        for mesh in meshes {
+            let vertexBuffer = mesh.vertexBuffers[0]
+            commandEncoder.setVertexBuffer(vertexBuffer.buffer, offset: vertexBuffer.offset, index: 0)
+            for submesh in mesh.submeshes {
+                commandEncoder.drawIndexedPrimitives(type: submesh.primitiveType,
+                                                     indexCount: submesh.indexCount,
+                                                     indexType: submesh.indexType,
+                                                     indexBuffer: submesh.indexBuffer.buffer,
+                                                     indexBufferOffset: submesh.indexBuffer.offset,
+                                                     instanceCount: 40)
             }
         }
-        }
-            
+        
+//        MARK: 40 Ttouches, Per-object Draw Call
+
+         for _ in 0..<40 {
+             var sourceModelConstants = ModelConstants()
+             
+             let ttouchScaleMatrix = matrix_float4x4(scaleX: Float(generator.next(upperBound: 5)), y: Float(generator.next(upperBound: 5)), z: Float(generator.next(upperBound: 5)))
+             let ttouchTranslationMatrix = matrix_float4x4(translationX: Float(generator.next(upperBound: 5))-2, y: Float(generator.next(upperBound: 5))-3, z: -5)
+             sourceModelConstants.modelViewMatrix = matrix_multiply(ttouchTranslationMatrix, ttouchScaleMatrix)
+             
+             commandEncoder.setVertexBytes(&sourceModelConstants, length: MemoryLayout<ModelConstants>.stride, index: 1)
+             
+             commandEncoder.setFragmentTexture(ttouchTexture, index: 0)
+             
+             guard let meshes = self.meshes?.1 as? [MTKMesh], meshes.count > 0 else { return }
+             
+             for mesh in meshes {
+                 let vertexBuffer = mesh.vertexBuffers[0]
+                 commandEncoder.setVertexBuffer(vertexBuffer.buffer, offset: vertexBuffer.offset, index: 0)
+                 for submesh in mesh.submeshes {
+                     commandEncoder.drawIndexedPrimitives(type: submesh.primitiveType,
+                                                          indexCount: submesh.indexCount,
+                                                          indexType: submesh.indexType,
+                                                          indexBuffer: submesh.indexBuffer.buffer,
+                                                          indexBufferOffset: submesh.indexBuffer.offset)
+                 }
+             }
+         }
+
+        
+    }
+    
 }
 
 
@@ -177,3 +213,4 @@ class InstanceScene: Renderer {
 #Preview {
     ContentView()
 }
+

--- a/learnMetal_2/Shaders.metal
+++ b/learnMetal_2/Shaders.metal
@@ -40,6 +40,21 @@ vertex VertexOut vertex_shader(const VertexIn vertexIn [[ stage_in ]],
     return vertexOut;
 }
 
+vertex VertexOut instanced_vertex_shader(const VertexIn vertexIn [[ stage_in ]],
+                                         constant ModelConstants *instances [[ buffer(1) ]],
+                                         constant SceneConstants &sceneConstants [[ buffer(2) ]],
+                                         uint instanceId [[ instance_id ]]) {
+    ModelConstants modelConstants = instances[instanceId];
+    
+    VertexOut vertexOut;
+    float4x4 matrix = sceneConstants.sceneViewMatrix * modelConstants.modelViewMatrix;
+    vertexOut.position = matrix * vertexIn.position;
+    vertexOut.color = vertexIn.color;
+    vertexOut.textureCoordinates = vertexIn.textureCoordinates;
+    
+    return vertexOut;
+}
+
 fragment half4 fragment_shader(VertexOut vertexIn [[ stage_in ]]) {
     return half4(vertexIn.color);
 }

--- a/learnMetal_2/Utilities/Types.swift
+++ b/learnMetal_2/Utilities/Types.swift
@@ -29,3 +29,15 @@ struct Vertex {
 struct Primitive {
     
 }
+
+struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { self.state = seed }
+    mutating func next() -> UInt64 {
+        state = state &* 6364136223846793005 &+ 1
+        return state
+    }
+    mutating func next(upperBound: UInt32) -> UInt32 {
+        return UInt32(next() % UInt64(upperBound))
+    }
+}


### PR DESCRIPTION
close #7 

드로우 콜을 40번 할 것을 1번으로 줄여주는 방식
마치 라면 40개를 1인분 냄비에 하나씩 조리해서 나가는 거랑 큰 냄비에 40개를 한 번에 넣어서 조리하는 것 같은 느낌이랄까?
드로우 메서드 호출이 많아질수록 후자가 빠를 것. 40번 조리할 것을 한 번만 조리하면 되니깐

### 원래 구조(오브젝트 하나씩 드로우)
하나 그릴 때마다 하나씩 처리
```
//pseudo code
for _ in 0..<40 {
    var 행렬 데이터
    행렬 데이터 매트릭스 변환 코드
    setVertexBuffer(...)
    for mesh in meshes {
        for submesh in mesh.submeshes {
        drawIndexedPrimitive(...)
    }
}
```

### 인스턴싱
위치,정보,회전 데이터를 한 번에 처리한 후 드로우 콜 1번. 전자에 비해 드로우 호출이 1/40 수준으로 줄어들어 리소스를 아낀다는 느낌
```
//pseudo code
var 행렬 데이터 배열
for _ in 0..<40 {
    배열 요소에 매트릭스 계산 코드
}
setVertexBuffer(...)
for mesh in meshes {
        for submesh in mesh.submeshes {
        drawIndexedPrimitive(...)
    }
}
```

하지만 실제 리소스 사용량을 보면,
**오브젝트 하나씩 드로우**
<img width="1624" height="994" alt="스크린샷 2025-09-16 15 33 14" src="https://github.com/user-attachments/assets/9393144f-a985-476f-9935-aff038651316" />
**인스턴싱**
<img width="1624" height="994" alt="스크린샷 2025-09-16 15 29 36" src="https://github.com/user-attachments/assets/ebb8de9f-a69b-4f40-906c-bf91b2a46986" />

큰 차이가 없다.
아마도 모델 소스가 그렇게 무거운 게 아니라서 그런 듯? 땃쥐 40개 정도는 
<img width="262" height="520" alt="스크린샷 2025-09-16 15 34 04" src="https://github.com/user-attachments/assets/f0dcd3c2-ec8a-4e6d-b490-ed9651040aab" />

### 결론!
버텍스 2만2천(550*40)개 정도는 그렇게 무거운 게 아니다!
