### PR TITLE
환경광 구현 + 뷰 회전 구현

### DIFF
--- a/learnMetal_2/App/ContentView.swift
+++ b/learnMetal_2/App/ContentView.swift
@@ -22,20 +22,314 @@ struct metalView: UIViewRepresentable {
     }
     
     func makeUIView(context: Context) -> MTKView {
-        let mtkView = MTKView()
+        let mtkView = TouchMTKView()
         mtkView.device = MTLCreateSystemDefaultDevice()
         mtkView.clearColor = Colors.wenderlichGreen
 
         let delegate = MetalViewDelegate(metalView: mtkView)
         mtkView.delegate = delegate
+        mtkView.touchProxy = delegate
+        
         context.coordinator.delegate = delegate
         return mtkView
     }
     
-    func updateUIView(_ uiView: MTKView, context: Context) {}
+    func updateUIView(_ uiView: MTKView, context: Context) {
+        
+    }
     
     class Coordinator {
         var delegate: MetalViewDelegate?
+    }
+}
+
+class TouchMTKView: MTKView {
+    weak var touchProxy: MetalViewDelegate?
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        touchProxy?.handleTouchesBegan(touches, in: self)
+    }
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        touchProxy?.handleTouchesMoved(touches, in: self)
+    }
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        touchProxy?.handleTouchesEnded(touches, in: self)
+    }
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        touchProxy?.handleTouchesCancelled(touches, in: self)
+    }
+}
+
+class MetalViewDelegate : NSObject, MTKViewDelegate {
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    
+    private var samplerState: MTLSamplerState?
+    private var depthStencilState: MTLDepthStencilState?
+    
+    private var time: Float = 0.0
+    
+    
+    //화면 회전
+    private var yaw: Float = 0
+    private var pitch: Float = 0
+    private var previousTouch: CGPoint = .zero
+    private let sensitivity: Float = 0.01
+    
+    init?(metalView: MTKView){
+        self.device = metalView.device ?? MTLCreateSystemDefaultDevice()!
+        self.commandQueue = self.device.makeCommandQueue()!
+        super.init()
+    
+        metalView.depthStencilPixelFormat = .depth32Float
+        
+        buildSamplerState()
+        buildDepthStencilState()
+    }
+    
+    func handleTouchesBegan(_ touches: Set<UITouch>, in view: UIView) {
+        guard let t = touches.first else { return }
+        previousTouch = t.location(in: view)
+    }
+    func handleTouchesMoved(_ touches: Set<UITouch>, in view: UIView) {
+        guard let t = touches.first else { return }
+        let loc = t.location(in: view)
+        let dx = Float(previousTouch.x - loc.x)
+        let dy = Float(previousTouch.y - loc.y)
+        
+        pitch += dy * sensitivity
+        yaw += dx * sensitivity
+        
+        previousTouch = loc
+    }
+    func handleTouchesEnded(_ touches: Set<UITouch>, in view: UIView) {}
+    func handleTouchesCancelled(_ touches: Set<UITouch>, in view: UIView) {}
+    
+    private func buildSamplerState() {
+        let descriptor = MTLSamplerDescriptor()
+        descriptor.minFilter = .linear
+        descriptor.magFilter = .linear
+        self.samplerState = device.makeSamplerState(descriptor: descriptor)
+    }
+    
+    private func buildDepthStencilState() {
+        let depthStencilDescriptor = MTLDepthStencilDescriptor()
+        depthStencilDescriptor.depthCompareFunction = .less
+        depthStencilDescriptor.isDepthWriteEnabled = true
+        depthStencilState = device.makeDepthStencilState(descriptor: depthStencilDescriptor)
+    }
+    
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        
+    }
+    
+    func draw(in view: MTKView) {
+        guard let renderPassDescriptor = view.currentRenderPassDescriptor,
+              let drawable = view.currentDrawable else
+        { return }
+        
+        guard let commandBuffer = commandQueue.makeCommandBuffer() else { return }
+        guard let commandEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else { return }
+        commandEncoder.setFragmentSamplerState(samplerState, index: 0)
+        commandEncoder.setDepthStencilState(depthStencilState)
+        commandEncoder.setFrontFacing(.counterClockwise)
+        commandEncoder.setCullMode(.back)
+        
+        time += 1 / Float(view.preferredFramesPerSecond)
+        
+        let modelScene = InstanceScene(device: device, view: view, rotation: SIMD2<Float>(yaw, pitch))
+//        let modelScene = ModelScene(device: device, view: view, time: time)
+        modelScene.render(commandEncoder: commandEncoder)
+        
+        commandEncoder.endEncoding()
+        commandBuffer.present(drawable)
+        commandBuffer.commit()
+    }
+}
+
+class InstanceScene: Renderer {
+    
+    var generator = SeededGenerator(seed: 1234)
+    
+    let device: MTLDevice
+    let view: MTKView
+    var rotation: SIMD2<Float>
+    
+    var objShader: MTLRenderPipelineState?
+    
+    var ttouchTexture: MTLTexture?
+    var texture: MTLTexture?
+    
+    var meshes: ([MDLMesh], [MTKMesh])?
+    
+    var light = Light()
+    
+    init(device: MTLDevice, view: MTKView, rotation: SIMD2<Float>) {
+        self.device = device
+        self.view = view
+        self.rotation = rotation
+        
+        objShader = buildOBJPipelineState(frag: "fragment_litTexture")
+        if let ttouchTexture = setTexture(device: device, imageName: "Texture_01.png") {
+            self.ttouchTexture = ttouchTexture
+        }
+        self.meshes = loadModel(device: device, modelName: "Ttouch")
+        
+        light.color = SIMD3<Float>(0, 0, 1)
+        light.ambientIntensity = 0.5
+    }
+    
+    private func setTexture(device: MTLDevice, imageName: String) -> MTLTexture? {
+        let textureLoader = MTKTextureLoader(device:device)
+        var texture: MTLTexture? = nil
+        
+        let textureLoaderOptions: [MTKTextureLoader.Option: Any] = [.origin: MTKTextureLoader.Origin.bottomLeft]
+        if let textureURL = Bundle.main.url(forResource: imageName, withExtension: nil) {
+            do {
+                texture = try textureLoader.newTexture(URL: textureURL, options: textureLoaderOptions)
+            } catch {
+                print("texture not created")
+            }
+        }
+        
+        return texture
+    }
+    
+    private func buildOBJPipelineState(frag: String) -> MTLRenderPipelineState? {
+        guard let library = device.makeDefaultLibrary(),
+              let vertexFunction = library.makeFunction(name: "instanced_vertex_shader"),
+              let fragmentFunction = library.makeFunction(name: frag)
+        else { return nil }
+        
+        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+        
+        pipelineDescriptor.vertexFunction = vertexFunction
+        pipelineDescriptor.fragmentFunction = fragmentFunction
+        pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+        pipelineDescriptor.depthAttachmentPixelFormat = .depth32Float
+        
+        let vertexDescriptor = buildVertexDescriptor()
+        
+        pipelineDescriptor.vertexDescriptor = vertexDescriptor
+        
+        do {
+            let pipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+            return pipelineState
+        } catch let error as NSError {
+            print("error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+    
+    private func buildVertexDescriptor() -> MTLVertexDescriptor {
+        let vertexDescriptor = MTLVertexDescriptor()
+        
+        vertexDescriptor.attributes[0].format = .float3
+        vertexDescriptor.attributes[0].offset = 0
+        vertexDescriptor.attributes[0].bufferIndex = 0
+        
+        vertexDescriptor.attributes[1].format = .float4
+        vertexDescriptor.attributes[1].offset = MemoryLayout<Float>.stride * 3
+        vertexDescriptor.attributes[1].bufferIndex = 0
+        
+        vertexDescriptor.attributes[2].format = .float2
+        vertexDescriptor.attributes[2].offset = MemoryLayout<Float>.stride * 7
+        vertexDescriptor.attributes[2].bufferIndex = 0
+        
+        vertexDescriptor.attributes[3].format = .float3
+        vertexDescriptor.attributes[3].offset = MemoryLayout<Float>.stride * 9
+        vertexDescriptor.attributes[3].bufferIndex = 0
+        
+        vertexDescriptor.layouts[0].stride = MemoryLayout<Float>.stride * 12
+        
+        return vertexDescriptor
+    }
+    
+    private func loadModel(device: MTLDevice, modelName: String) -> ([MDLMesh], [MTKMesh])? {
+        guard let assetURL = Bundle.main.url(forResource: modelName, withExtension: "obj") else {
+            fatalError("Asset \(modelName) dose not exist.")
+        }
+        
+        let vertexDescriptor = buildVertexDescriptor()
+        let descriptor = MTKModelIOVertexDescriptorFromMetal(vertexDescriptor)
+        
+        let attributePosition = descriptor.attributes[0] as! MDLVertexAttribute
+        attributePosition.name = MDLVertexAttributePosition
+        descriptor.attributes[0] = attributePosition
+        
+        let attributeColor = descriptor.attributes[1] as! MDLVertexAttribute
+        attributeColor.name = MDLVertexAttributeColor
+        descriptor.attributes[1] = attributeColor
+        
+        let attributeTexture = descriptor.attributes[2] as! MDLVertexAttribute
+        attributeTexture.name = MDLVertexAttributeTextureCoordinate
+        descriptor.attributes[2] = attributeTexture
+        
+        let attributeNormal = descriptor.attributes[3] as! MDLVertexAttribute
+        attributeNormal.name = MDLVertexAttributeNormal
+        descriptor.attributes[3] = attributeNormal
+        
+        let bufferAllocator = MTKMeshBufferAllocator(device: device)
+        let asset = MDLAsset(url: assetURL, vertexDescriptor: descriptor, bufferAllocator: bufferAllocator)
+        
+        do {
+            let meshes = try MTKMesh.newMeshes(asset: asset, device: device)
+            return meshes
+        } catch {
+            print("mesh error")
+            return nil
+        }
+    }
+    
+    func render(commandEncoder: MTLRenderCommandEncoder) {
+        guard let objShader = self.objShader else { return }
+        commandEncoder.setRenderPipelineState(objShader)
+        
+        var sceneConstants = SceneConstants()
+        let aspect = Float(view.drawableSize.width / view.drawableSize.height)
+        let sceneProjectionMatrix = matrix_float4x4(fovY: radians(degrees:65), aspect: aspect, near: 0.1, far: 100)
+        
+        let rotX = matrix_float4x4(rotationAngle: rotation.y, x: 1, y: 0, z: 0)
+        let rotY = matrix_float4x4(rotationAngle: rotation.x, x: 0, y: 1, z: 0)
+        
+        let sceneTranslationMatrix = matrix_float4x4(translationX: 0, y: -1, z: -5)
+        
+        let modelMatrix = matrix_multiply(rotY, rotX)
+        let modelViewMatrix = matrix_multiply(sceneTranslationMatrix, modelMatrix)
+        
+        let sceneViewMatrix = matrix_multiply(sceneProjectionMatrix, modelViewMatrix)
+        sceneConstants.sceneViewMatrix = sceneViewMatrix
+        
+        commandEncoder.setVertexBytes(&sceneConstants, length: MemoryLayout<SceneConstants>.stride,
+                                      index: 2)
+        
+        commandEncoder.setFragmentBytes(&light, length: MemoryLayout<Light>.stride, index: 3)
+        
+//        MARK: 40 Ttouches, Instancing, One Draw Call
+        var sourceModelConstantsArray = [ModelConstants](repeating: ModelConstants(), count: 40)
+        guard let meshes = self.meshes?.1 as? [MTKMesh], meshes.count > 0 else { return }
+        
+        for i in 0..<40 {
+            let ttouchScaleMatrix = matrix_float4x4(scaleX: Float(generator.next(upperBound: 5)), y: Float(generator.next(upperBound: 5)), z: Float(generator.next(upperBound: 5)))
+            let ttouchTranslationMatrix = matrix_float4x4(translationX: Float(generator.next(upperBound: 5))-2, y: Float(generator.next(upperBound: 5))-3, z: -5)
+            sourceModelConstantsArray[i].modelViewMatrix = matrix_multiply(ttouchTranslationMatrix, ttouchScaleMatrix)
+        }
+        
+        commandEncoder.setVertexBytes(&sourceModelConstantsArray, length: MemoryLayout<ModelConstants>.stride * sourceModelConstantsArray.count, index: 1)
+        commandEncoder.setFragmentTexture(ttouchTexture, index: 0)
+        
+        for mesh in meshes {
+            let vertexBuffer = mesh.vertexBuffers[0]
+            commandEncoder.setVertexBuffer(vertexBuffer.buffer, offset: vertexBuffer.offset, index: 0)
+            for submesh in mesh.submeshes {
+                commandEncoder.drawIndexedPrimitives(type: submesh.primitiveType,
+                                                     indexCount: submesh.indexCount,
+                                                     indexType: submesh.indexType,
+                                                     indexBuffer: submesh.indexBuffer.buffer,
+                                                     indexBufferOffset: submesh.indexBuffer.offset,
+                                                     instanceCount: 40)
+            }
+        }
     }
 }
 

--- a/learnMetal_2/App/MetalViewDelegate.swift
+++ b/learnMetal_2/App/MetalViewDelegate.swift
@@ -7,71 +7,93 @@
 import SwiftUI
 import MetalKit
 
-class MetalViewDelegate : NSObject, MTKViewDelegate {
-    let device: MTLDevice
-    let commandQueue: MTLCommandQueue
-    
-    var samplerState: MTLSamplerState?
-    var depthStencilState: MTLDepthStencilState?
-    
-    var time: Float = 0.0
-    
-    
-    init?(metalView: MTKView){
-        self.device = metalView.device ?? MTLCreateSystemDefaultDevice()!
-        self.commandQueue = self.device.makeCommandQueue()!
-        super.init()
-    
-        metalView.depthStencilPixelFormat = .depth32Float
-        
-        buildSamplerState()
-        buildDepthStencilState()
-    }
-    
-    private func buildSamplerState() {
-        let descriptor = MTLSamplerDescriptor()
-        descriptor.minFilter = .linear
-        descriptor.magFilter = .linear
-        self.samplerState = device.makeSamplerState(descriptor: descriptor)
-    }
-    
-    private func buildDepthStencilState() {
-        let depthStencilDescriptor = MTLDepthStencilDescriptor()
-        depthStencilDescriptor.depthCompareFunction = .less
-        depthStencilDescriptor.isDepthWriteEnabled = true
-        depthStencilState = device.makeDepthStencilState(descriptor: depthStencilDescriptor)
-    }
-    
-
-    
-    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
-        
-    }
-    
-    func draw(in view: MTKView) {
-        guard let renderPassDescriptor = view.currentRenderPassDescriptor,
-              let drawable = view.currentDrawable else
-        { return }
-        
-        guard let commandBuffer = commandQueue.makeCommandBuffer() else { return }
-        guard let commandEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else { return }
-        commandEncoder.setFragmentSamplerState(samplerState, index: 0)
-        commandEncoder.setDepthStencilState(depthStencilState)
-        commandEncoder.setFrontFacing(.counterClockwise)
-        commandEncoder.setCullMode(.back)
-        
-        time += 1 / Float(view.preferredFramesPerSecond)
-        
-        let modelScene = InstanceScene(device: device, view: view)
-//        let modelScene = ModelScene(device: device, view: view, time: time)
-        modelScene.render(commandEncoder: commandEncoder)
-        
-        commandEncoder.endEncoding()
-        commandBuffer.present(drawable)
-        commandBuffer.commit()
-    }
-}
-
-#Preview {
-    ContentView()
-}
+//class MetalViewDelegate : NSObject, MTKViewDelegate {
+//    private let device: MTLDevice
+//    private let commandQueue: MTLCommandQueue
+//    
+//    private var samplerState: MTLSamplerState?
+//    private var depthStencilState: MTLDepthStencilState?
+//    
+//    private var time: Float = 0.0
+//    
+//    
+//    //화면 회전
+//    private var yaw: Float = 0
+//    private var pitch: Float = 0
+//    private var previousTouch: CGPoint = .zero
+//    private let sensitivity: Float = 0.01
+//    
+//    init?(metalView: MTKView){
+//        self.device = metalView.device ?? MTLCreateSystemDefaultDevice()!
+//        self.commandQueue = self.device.makeCommandQueue()!
+//        super.init()
+//    
+//        metalView.depthStencilPixelFormat = .depth32Float
+//        
+//        buildSamplerState()
+//        buildDepthStencilState()
+//    }
+//    
+//    func handleTouchesBegan(_ touches: Set<UITouch>, in view: UIView) {
+//        guard let t = touches.first else { return }
+//        previousTouch = t.location(in: view)
+//    }
+//    func handleTouchesMoved(_ touches: Set<UITouch>, in view: UIView) {
+//        guard let t = touches.first else { return }
+//        let loc = t.location(in: view)
+//        let dx = Float(previousTouch.x - loc.x)
+//        let dy = Float(previousTouch.y - loc.y)
+//        
+//        pitch += dy * sensitivity
+//        yaw += dx * sensitivity
+//        
+//        previousTouch = loc
+//    }
+//    func handleTouchesEnded(_ touches: Set<UITouch>, in view: UIView) {}
+//    func handleTouchesCancelled(_ touches: Set<UITouch>, in view: UIView) {}
+//    
+//    private func buildSamplerState() {
+//        let descriptor = MTLSamplerDescriptor()
+//        descriptor.minFilter = .linear
+//        descriptor.magFilter = .linear
+//        self.samplerState = device.makeSamplerState(descriptor: descriptor)
+//    }
+//    
+//    private func buildDepthStencilState() {
+//        let depthStencilDescriptor = MTLDepthStencilDescriptor()
+//        depthStencilDescriptor.depthCompareFunction = .less
+//        depthStencilDescriptor.isDepthWriteEnabled = true
+//        depthStencilState = device.makeDepthStencilState(descriptor: depthStencilDescriptor)
+//    }
+//    
+//    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+//        
+//    }
+//    
+//    func draw(in view: MTKView) {
+//        guard let renderPassDescriptor = view.currentRenderPassDescriptor,
+//              let drawable = view.currentDrawable else
+//        { return }
+//        
+//        guard let commandBuffer = commandQueue.makeCommandBuffer() else { return }
+//        guard let commandEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else { return }
+//        commandEncoder.setFragmentSamplerState(samplerState, index: 0)
+//        commandEncoder.setDepthStencilState(depthStencilState)
+//        commandEncoder.setFrontFacing(.counterClockwise)
+//        commandEncoder.setCullMode(.back)
+//        
+//        time += 1 / Float(view.preferredFramesPerSecond)
+//        
+//        let modelScene = InstanceScene(device: device, view: view)
+////        let modelScene = ModelScene(device: device, view: view, time: time)
+//        modelScene.render(commandEncoder: commandEncoder)
+//        
+//        commandEncoder.endEncoding()
+//        commandBuffer.present(drawable)
+//        commandBuffer.commit()
+//    }
+//}
+//
+//#Preview {
+//    ContentView()
+//}

--- a/learnMetal_2/Scenes/InstanceScene.swift
+++ b/learnMetal_2/Scenes/InstanceScene.swift
@@ -7,210 +7,185 @@
 import SwiftUI
 import MetalKit
 
-class InstanceScene: Renderer {
-    
-    var generator = SeededGenerator(seed: 1234)
-    
-    let device: MTLDevice
-    let view: MTKView
-    
-    var objShader: MTLRenderPipelineState?
-    
-    var ttouchTexture: MTLTexture?
-    var texture: MTLTexture?
-    
-    var meshes: ([MDLMesh], [MTKMesh])?
-    
-    init(device: MTLDevice, view: MTKView) {
-        self.device = device
-        self.view = view
-        
-        objShader = buildOBJPipelineState(frag: "defaultTexture")
-        if let ttouchTexture = setTexture(device: device, imageName: "Texture_01.png") {
-            self.ttouchTexture = ttouchTexture
-        }
-        self.meshes = loadModel(device: device, modelName: "Ttouch")
-    }
-    
-    private func setTexture(device: MTLDevice, imageName: String) -> MTLTexture? {
-        let textureLoader = MTKTextureLoader(device:device)
-        var texture: MTLTexture? = nil
-        
-        let textureLoaderOptions: [MTKTextureLoader.Option: Any] = [.origin: MTKTextureLoader.Origin.bottomLeft]
-        if let textureURL = Bundle.main.url(forResource: imageName, withExtension: nil) {
-            do {
-                texture = try textureLoader.newTexture(URL: textureURL, options: textureLoaderOptions)
-            } catch {
-                print("texture not created")
-            }
-        }
-        
-        return texture
-    }
-    
-    private func buildOBJPipelineState(frag: String) -> MTLRenderPipelineState? {
-        guard let library = device.makeDefaultLibrary(),
-              let vertexFunction = library.makeFunction(name: "instanced_vertex_shader"),
-              let fragmentFunction = library.makeFunction(name: frag)
-        else { return nil }
-        
-        let pipelineDescriptor = MTLRenderPipelineDescriptor()
-        
-        pipelineDescriptor.vertexFunction = vertexFunction
-        pipelineDescriptor.fragmentFunction = fragmentFunction
-        pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
-        pipelineDescriptor.depthAttachmentPixelFormat = .depth32Float
-        
-        let vertexDescriptor = buildVertexDescriptor()
-        
-        pipelineDescriptor.vertexDescriptor = vertexDescriptor
-        
-        do {
-            let pipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
-            return pipelineState
-        } catch let error as NSError {
-            print("error: \(error.localizedDescription)")
-            return nil
-        }
-    }
-    
-    private func buildVertexDescriptor() -> MTLVertexDescriptor {
-        let vertexDescriptor = MTLVertexDescriptor()
-        
-        vertexDescriptor.attributes[0].format = .float3
-        vertexDescriptor.attributes[0].offset = 0
-        vertexDescriptor.attributes[0].bufferIndex = 0
-        
-        vertexDescriptor.attributes[1].format = .float4
-        vertexDescriptor.attributes[1].offset = MemoryLayout<Float>.stride * 3
-        vertexDescriptor.attributes[1].bufferIndex = 0
-        
-        vertexDescriptor.attributes[2].format = .float2
-        vertexDescriptor.attributes[2].offset = MemoryLayout<Float>.stride * 7
-        vertexDescriptor.attributes[2].bufferIndex = 0
-        
-        vertexDescriptor.attributes[3].format = .float3
-        vertexDescriptor.attributes[3].offset = MemoryLayout<Float>.stride * 9
-        vertexDescriptor.attributes[3].bufferIndex = 0
-        
-        vertexDescriptor.layouts[0].stride = MemoryLayout<Float>.stride * 12
-        
-        return vertexDescriptor
-    }
-    
-    private func loadModel(device: MTLDevice, modelName: String) -> ([MDLMesh], [MTKMesh])? {
-        guard let assetURL = Bundle.main.url(forResource: modelName, withExtension: "obj") else {
-            fatalError("Asset \(modelName) dose not exist.")
-        }
-        
-        let vertexDescriptor = buildVertexDescriptor()
-        let descriptor = MTKModelIOVertexDescriptorFromMetal(vertexDescriptor)
-        
-        let attributePosition = descriptor.attributes[0] as! MDLVertexAttribute
-        attributePosition.name = MDLVertexAttributePosition
-        descriptor.attributes[0] = attributePosition
-        
-        let attributeColor = descriptor.attributes[1] as! MDLVertexAttribute
-        attributeColor.name = MDLVertexAttributeColor
-        descriptor.attributes[1] = attributeColor
-        
-        let attributeTexture = descriptor.attributes[2] as! MDLVertexAttribute
-        attributeTexture.name = MDLVertexAttributeTextureCoordinate
-        descriptor.attributes[2] = attributeTexture
-        
-        let attributeNormal = descriptor.attributes[3] as! MDLVertexAttribute
-        attributeNormal.name = MDLVertexAttributeNormal
-        descriptor.attributes[3] = attributeNormal
-        
-        let bufferAllocator = MTKMeshBufferAllocator(device: device)
-        let asset = MDLAsset(url: assetURL, vertexDescriptor: descriptor, bufferAllocator: bufferAllocator)
-        
-        do {
-            let meshes = try MTKMesh.newMeshes(asset: asset, device: device)
-            return meshes
-        } catch {
-            print("mesh error")
-            return nil
-        }
-    }
-    
-    func render(commandEncoder: MTLRenderCommandEncoder) {
-        guard let objShader = self.objShader else { return }
-        commandEncoder.setRenderPipelineState(objShader)
-        
-        var sceneConstants = SceneConstants()
-        let sceneProjectionMatrix = matrix_float4x4(fovY: radians(degrees:65), aspect: 1, near: 0.1, far: 100)
-        let sceneTranslationMatrix = matrix_float4x4(translationX: 0, y: -1, z: -5)
-        
-        let sceneViewMatrix = matrix_multiply(sceneProjectionMatrix, sceneTranslationMatrix)
-        sceneConstants.sceneViewMatrix = sceneViewMatrix
-        
-        commandEncoder.setVertexBytes(&sceneConstants, length: MemoryLayout<SceneConstants>.stride,
-                                      index: 2)
-        
-        
-//        MARK: 40 Ttouches, Instancing, One Draw Call
-        var sourceModelConstantsArray = [ModelConstants](repeating: ModelConstants(), count: 40)
-        guard let meshes = self.meshes?.1 as? [MTKMesh], meshes.count > 0 else { return }
-        
-        for i in 0..<40 {
-            let ttouchScaleMatrix = matrix_float4x4(scaleX: Float(generator.next(upperBound: 5)), y: Float(generator.next(upperBound: 5)), z: Float(generator.next(upperBound: 5)))
-            let ttouchTranslationMatrix = matrix_float4x4(translationX: Float(generator.next(upperBound: 5))-2, y: Float(generator.next(upperBound: 5))-3, z: -5)
-            sourceModelConstantsArray[i].modelViewMatrix = matrix_multiply(ttouchTranslationMatrix, ttouchScaleMatrix)
-        }
-        
-        commandEncoder.setVertexBytes(&sourceModelConstantsArray, length: MemoryLayout<ModelConstants>.stride * sourceModelConstantsArray.count, index: 1)
-        commandEncoder.setFragmentTexture(ttouchTexture, index: 0)
-        
-        for mesh in meshes {
-            let vertexBuffer = mesh.vertexBuffers[0]
-            commandEncoder.setVertexBuffer(vertexBuffer.buffer, offset: vertexBuffer.offset, index: 0)
-            for submesh in mesh.submeshes {
-                commandEncoder.drawIndexedPrimitives(type: submesh.primitiveType,
-                                                     indexCount: submesh.indexCount,
-                                                     indexType: submesh.indexType,
-                                                     indexBuffer: submesh.indexBuffer.buffer,
-                                                     indexBufferOffset: submesh.indexBuffer.offset,
-                                                     instanceCount: 40)
-            }
-        }
-        
-//        MARK: 40 Ttouches, Per-object Draw Call
-
-         for _ in 0..<40 {
-             var sourceModelConstants = ModelConstants()
-             
-             let ttouchScaleMatrix = matrix_float4x4(scaleX: Float(generator.next(upperBound: 5)), y: Float(generator.next(upperBound: 5)), z: Float(generator.next(upperBound: 5)))
-             let ttouchTranslationMatrix = matrix_float4x4(translationX: Float(generator.next(upperBound: 5))-2, y: Float(generator.next(upperBound: 5))-3, z: -5)
-             sourceModelConstants.modelViewMatrix = matrix_multiply(ttouchTranslationMatrix, ttouchScaleMatrix)
-             
-             commandEncoder.setVertexBytes(&sourceModelConstants, length: MemoryLayout<ModelConstants>.stride, index: 1)
-             
-             commandEncoder.setFragmentTexture(ttouchTexture, index: 0)
-             
-             guard let meshes = self.meshes?.1 as? [MTKMesh], meshes.count > 0 else { return }
-             
-             for mesh in meshes {
-                 let vertexBuffer = mesh.vertexBuffers[0]
-                 commandEncoder.setVertexBuffer(vertexBuffer.buffer, offset: vertexBuffer.offset, index: 0)
-                 for submesh in mesh.submeshes {
-                     commandEncoder.drawIndexedPrimitives(type: submesh.primitiveType,
-                                                          indexCount: submesh.indexCount,
-                                                          indexType: submesh.indexType,
-                                                          indexBuffer: submesh.indexBuffer.buffer,
-                                                          indexBufferOffset: submesh.indexBuffer.offset)
-                 }
-             }
-         }
-
-        
-    }
-    
-}
-
-
-
-#Preview {
-    ContentView()
-}
-
+//class InstanceScene: Renderer {
+//    
+//    var generator = SeededGenerator(seed: 1234)
+//    
+//    let device: MTLDevice
+//    let view: MTKView
+//    
+//    var objShader: MTLRenderPipelineState?
+//    
+//    var ttouchTexture: MTLTexture?
+//    var texture: MTLTexture?
+//    
+//    var meshes: ([MDLMesh], [MTKMesh])?
+//    
+//    var light = Light()
+//    
+//    init(device: MTLDevice, view: MTKView) {
+//        self.device = device
+//        self.view = view
+//        
+//        objShader = buildOBJPipelineState(frag: "fragment_litTexture")
+//        if let ttouchTexture = setTexture(device: device, imageName: "Texture_01.png") {
+//            self.ttouchTexture = ttouchTexture
+//        }
+//        self.meshes = loadModel(device: device, modelName: "Ttouch")
+//        
+//        light.color = SIMD3<Float>(0, 0, 1)
+//        light.ambientIntensity = 0.5
+//    }
+//    
+//    private func setTexture(device: MTLDevice, imageName: String) -> MTLTexture? {
+//        let textureLoader = MTKTextureLoader(device:device)
+//        var texture: MTLTexture? = nil
+//        
+//        let textureLoaderOptions: [MTKTextureLoader.Option: Any] = [.origin: MTKTextureLoader.Origin.bottomLeft]
+//        if let textureURL = Bundle.main.url(forResource: imageName, withExtension: nil) {
+//            do {
+//                texture = try textureLoader.newTexture(URL: textureURL, options: textureLoaderOptions)
+//            } catch {
+//                print("texture not created")
+//            }
+//        }
+//        
+//        return texture
+//    }
+//    
+//    private func buildOBJPipelineState(frag: String) -> MTLRenderPipelineState? {
+//        guard let library = device.makeDefaultLibrary(),
+//              let vertexFunction = library.makeFunction(name: "instanced_vertex_shader"),
+//              let fragmentFunction = library.makeFunction(name: frag)
+//        else { return nil }
+//        
+//        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+//        
+//        pipelineDescriptor.vertexFunction = vertexFunction
+//        pipelineDescriptor.fragmentFunction = fragmentFunction
+//        pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+//        pipelineDescriptor.depthAttachmentPixelFormat = .depth32Float
+//        
+//        let vertexDescriptor = buildVertexDescriptor()
+//        
+//        pipelineDescriptor.vertexDescriptor = vertexDescriptor
+//        
+//        do {
+//            let pipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+//            return pipelineState
+//        } catch let error as NSError {
+//            print("error: \(error.localizedDescription)")
+//            return nil
+//        }
+//    }
+//    
+//    private func buildVertexDescriptor() -> MTLVertexDescriptor {
+//        let vertexDescriptor = MTLVertexDescriptor()
+//        
+//        vertexDescriptor.attributes[0].format = .float3
+//        vertexDescriptor.attributes[0].offset = 0
+//        vertexDescriptor.attributes[0].bufferIndex = 0
+//        
+//        vertexDescriptor.attributes[1].format = .float4
+//        vertexDescriptor.attributes[1].offset = MemoryLayout<Float>.stride * 3
+//        vertexDescriptor.attributes[1].bufferIndex = 0
+//        
+//        vertexDescriptor.attributes[2].format = .float2
+//        vertexDescriptor.attributes[2].offset = MemoryLayout<Float>.stride * 7
+//        vertexDescriptor.attributes[2].bufferIndex = 0
+//        
+//        vertexDescriptor.attributes[3].format = .float3
+//        vertexDescriptor.attributes[3].offset = MemoryLayout<Float>.stride * 9
+//        vertexDescriptor.attributes[3].bufferIndex = 0
+//        
+//        vertexDescriptor.layouts[0].stride = MemoryLayout<Float>.stride * 12
+//        
+//        return vertexDescriptor
+//    }
+//    
+//    private func loadModel(device: MTLDevice, modelName: String) -> ([MDLMesh], [MTKMesh])? {
+//        guard let assetURL = Bundle.main.url(forResource: modelName, withExtension: "obj") else {
+//            fatalError("Asset \(modelName) dose not exist.")
+//        }
+//        
+//        let vertexDescriptor = buildVertexDescriptor()
+//        let descriptor = MTKModelIOVertexDescriptorFromMetal(vertexDescriptor)
+//        
+//        let attributePosition = descriptor.attributes[0] as! MDLVertexAttribute
+//        attributePosition.name = MDLVertexAttributePosition
+//        descriptor.attributes[0] = attributePosition
+//        
+//        let attributeColor = descriptor.attributes[1] as! MDLVertexAttribute
+//        attributeColor.name = MDLVertexAttributeColor
+//        descriptor.attributes[1] = attributeColor
+//        
+//        let attributeTexture = descriptor.attributes[2] as! MDLVertexAttribute
+//        attributeTexture.name = MDLVertexAttributeTextureCoordinate
+//        descriptor.attributes[2] = attributeTexture
+//        
+//        let attributeNormal = descriptor.attributes[3] as! MDLVertexAttribute
+//        attributeNormal.name = MDLVertexAttributeNormal
+//        descriptor.attributes[3] = attributeNormal
+//        
+//        let bufferAllocator = MTKMeshBufferAllocator(device: device)
+//        let asset = MDLAsset(url: assetURL, vertexDescriptor: descriptor, bufferAllocator: bufferAllocator)
+//        
+//        do {
+//            let meshes = try MTKMesh.newMeshes(asset: asset, device: device)
+//            return meshes
+//        } catch {
+//            print("mesh error")
+//            return nil
+//        }
+//    }
+//    
+//    func render(commandEncoder: MTLRenderCommandEncoder) {
+//        guard let objShader = self.objShader else { return }
+//        commandEncoder.setRenderPipelineState(objShader)
+//        
+//        var sceneConstants = SceneConstants()
+//        let sceneProjectionMatrix = matrix_float4x4(fovY: radians(degrees:65), aspect: 1, near: 0.1, far: 100)
+//        let sceneTranslationMatrix = matrix_float4x4(translationX: 0, y: -1, z: -5)
+//        
+//        let sceneViewMatrix = matrix_multiply(sceneProjectionMatrix, sceneTranslationMatrix)
+//        sceneConstants.sceneViewMatrix = sceneViewMatrix
+//        
+//        commandEncoder.setVertexBytes(&sceneConstants, length: MemoryLayout<SceneConstants>.stride,
+//                                      index: 2)
+//        
+//        commandEncoder.setFragmentBytes(&light, length: MemoryLayout<Light>.stride, index: 3)
+//        
+////        MARK: 40 Ttouches, Instancing, One Draw Call
+//        var sourceModelConstantsArray = [ModelConstants](repeating: ModelConstants(), count: 40)
+//        guard let meshes = self.meshes?.1 as? [MTKMesh], meshes.count > 0 else { return }
+//        
+//        for i in 0..<40 {
+//            let ttouchScaleMatrix = matrix_float4x4(scaleX: Float(generator.next(upperBound: 5)), y: Float(generator.next(upperBound: 5)), z: Float(generator.next(upperBound: 5)))
+//            let ttouchTranslationMatrix = matrix_float4x4(translationX: Float(generator.next(upperBound: 5))-2, y: Float(generator.next(upperBound: 5))-3, z: -5)
+//            sourceModelConstantsArray[i].modelViewMatrix = matrix_multiply(ttouchTranslationMatrix, ttouchScaleMatrix)
+//        }
+//        
+//        commandEncoder.setVertexBytes(&sourceModelConstantsArray, length: MemoryLayout<ModelConstants>.stride * sourceModelConstantsArray.count, index: 1)
+//        commandEncoder.setFragmentTexture(ttouchTexture, index: 0)
+//        
+//        for mesh in meshes {
+//            let vertexBuffer = mesh.vertexBuffers[0]
+//            commandEncoder.setVertexBuffer(vertexBuffer.buffer, offset: vertexBuffer.offset, index: 0)
+//            for submesh in mesh.submeshes {
+//                commandEncoder.drawIndexedPrimitives(type: submesh.primitiveType,
+//                                                     indexCount: submesh.indexCount,
+//                                                     indexType: submesh.indexType,
+//                                                     indexBuffer: submesh.indexBuffer.buffer,
+//                                                     indexBufferOffset: submesh.indexBuffer.offset,
+//                                                     instanceCount: 40)
+//            }
+//        }
+//    }
+//}
+//
+//
+//
+//#Preview {
+//    ContentView()
+//}
+//

--- a/learnMetal_2/Scenes/ModelScene.swift
+++ b/learnMetal_2/Scenes/ModelScene.swift
@@ -39,8 +39,8 @@ class ModelScene: Renderer {
         
         buildBuffers()
         defaultShader = buildPipelineState(frag: "fragment_shader")
-        texturedShader = buildPipelineState(frag: "defaultTexture")
-        objShader = buildOBJPipelineState(frag: "defaultTexture")
+        texturedShader = buildPipelineState(frag: "fragment_texture")
+        objShader = buildOBJPipelineState(frag: "fragment_texture")
         self.meshes = loadModel(device: device, modelName: "Ttouch")
         if let texture = setTexture(device: device, imageName: "image.png") {
             self.texture = texture
@@ -250,32 +250,32 @@ class ModelScene: Renderer {
                                       indexBufferOffset: 0)
         
         //MARK: Plane
-//        var planeModelConstants = ModelConstants()
-//        
-//        let planeScaleMatrix = matrix_float4x4(scaleX: 4, y: 4, z: 4)
-//        let planeRotationMatrixX = matrix_float4x4(rotationAngle: radians(degrees: -45), x:1, y: 0, z: 0)
-//        let planeRotationMatrixY = matrix_float4x4(rotationAngle: radians(degrees: -45), x:0, y: 1, z: 0)
-//        let planeTranslationMatrix = matrix_float4x4(translationX: -3.5, y: 2, z: -5)
-//        let calcA = matrix_multiply(planeRotationMatrixX,planeRotationMatrixY)
-//        let calcB = matrix_multiply(calcA, planeScaleMatrix)
-//        
-//        
-//        planeModelConstants.modelViewMatrix = matrix_multiply( planeTranslationMatrix, calcB)
-//        
-//        commandEncoder.setRenderPipelineState(texturedShader)
-//        commandEncoder.setVertexBuffer(planeVertexBuffer, offset: 0, index: 0)
-//        commandEncoder.setVertexBytes(&planeModelConstants,
-//                                      length: MemoryLayout<ModelConstants>.stride,
-//                                      index: 1)
-//        commandEncoder.setFragmentTexture(texture, index: 0)
-//
-//   
-//        
-//        commandEncoder.drawIndexedPrimitives(type: .triangle,
-//                                             indexCount: plane.planeIndices.count,
-//                                      indexType: .uint16,
-//                                      indexBuffer: planeIndexBuffer,
-//                                      indexBufferOffset: 0)
+        var planeModelConstants = ModelConstants()
+        
+        let planeScaleMatrix = matrix_float4x4(scaleX: 4, y: 4, z: 4)
+        let planeRotationMatrixX = matrix_float4x4(rotationAngle: radians(degrees: -45), x:1, y: 0, z: 0)
+        let planeRotationMatrixY = matrix_float4x4(rotationAngle: radians(degrees: -45), x:0, y: 1, z: 0)
+        let planeTranslationMatrix = matrix_float4x4(translationX: -3.5, y: 2, z: -5)
+        let calcA = matrix_multiply(planeRotationMatrixX,planeRotationMatrixY)
+        let calcB = matrix_multiply(calcA, planeScaleMatrix)
+        
+        
+        planeModelConstants.modelViewMatrix = matrix_multiply( planeTranslationMatrix, calcB)
+        
+        commandEncoder.setRenderPipelineState(texturedShader)
+        commandEncoder.setVertexBuffer(planeVertexBuffer, offset: 0, index: 0)
+        commandEncoder.setVertexBytes(&planeModelConstants,
+                                      length: MemoryLayout<ModelConstants>.stride,
+                                      index: 1)
+        commandEncoder.setFragmentTexture(texture, index: 0)
+
+   
+        
+        commandEncoder.drawIndexedPrimitives(type: .triangle,
+                                             indexCount: plane.planeIndices.count,
+                                      indexType: .uint16,
+                                      indexBuffer: planeIndexBuffer,
+                                      indexBufferOffset: 0)
 
     //MARK: Ttouch
         

--- a/learnMetal_2/Shaders.metal
+++ b/learnMetal_2/Shaders.metal
@@ -28,6 +28,11 @@ struct VertexOut {
     float2 textureCoordinates;
 };
 
+struct Light {
+    float3 color;
+    float ambientIntensity;
+};
+
 vertex VertexOut vertex_shader(const VertexIn vertexIn [[ stage_in ]],
                                constant ModelConstants &modelConstants [[ buffer(1) ]],
                                constant SceneConstants &sceneConstants [[ buffer(2) ]]) {
@@ -69,12 +74,26 @@ fragment half4 fragment_grayShader(VertexOut vertexIn [[ stage_in ]]) {
     return half4(vertexOut.color);
 }
 
-fragment half4 defaultTexture(VertexOut vertexIn [[ stage_in ]],
+fragment half4 fragment_texture(VertexOut vertexIn [[ stage_in ]],
                                       sampler sampler2d [[ sampler(0)]],
                                       texture2d<float> texture [[ texture(0) ]]) {
     constexpr sampler defaultSampler;
     float4 color = texture.sample(defaultSampler, vertexIn.textureCoordinates);
     return half4(color.r, color.g, color.b, vertexIn.color.a);
+}
+
+fragment half4 fragment_litTexture(VertexOut vertexIn [[ stage_in ]],
+                                      sampler sampler2d [[ sampler(0) ]],
+                                   constant Light &light [[ buffer(3) ]],
+                                      texture2d<float> texture [[ texture(0) ]]) {
+    constexpr sampler defaultSampler;
+    float4 color = texture.sample(defaultSampler, vertexIn.textureCoordinates);
+    
+    float3 ambientColor = light.color * light.ambientIntensity;
+    color = color * float4(ambientColor, 1);
+    
+    return half4(color.r, color.g, color.b, vertexIn.color.a);
+    
 }
 
 fragment half4 maskedTexture(VertexOut vertexIn [[ stage_in ]],

--- a/learnMetal_2/Utilities/Types.swift
+++ b/learnMetal_2/Utilities/Types.swift
@@ -41,3 +41,8 @@ struct SeededGenerator: RandomNumberGenerator {
         return UInt32(next() % UInt64(upperBound))
     }
 }
+
+struct Light {
+    var color = SIMD3<Float>(repeating: 1)
+    var ambientIntensity: Float = 1.0
+}


### PR DESCRIPTION
close #11 
환경광은 기본 프래그먼트에 빛 색상 값을 곱하여 구현합니다.

```
//shaders.metal
fragment half4 fragment_litTexture(VertexOut vertexIn [[ stage_in ]],
                                      sampler sampler2d [[ sampler(0) ]],
                                   constant Light &light [[ buffer(3) ]],
                                      texture2d<float> texture [[ texture(0) ]]) {
    constexpr sampler defaultSampler;
    float4 color = texture.sample(defaultSampler, vertexIn.textureCoordinates);
    
    float3 ambientColor = light.color * light.ambientIntensity;
    color = color * float4(ambientColor, 1);
    
    return half4(color.r, color.g, color.b, vertexIn.color.a);
    
}
```
//InstanceScene.swift
빛 색상을 넘겨주기 위해서 swift에서는 당연하게도 buffer로 넘겨 주어야 합니다.
```
commandEncoder.setFragmentBytes(&light, length: MemoryLayout<Light>.stride, index: 3)
```

그리고 역시 당연하게도 빛을 표현하는 객체가 swift와 metal에 각각 있어야 하겠죠
```
//Types.swift
struct Light {
    var color = SIMD3<Float>(repeating: 1)
    var ambientIntensity: Float = 1.0
}

//Shaders.metal
struct Light {
    float3 color;
    float ambientIntensity;
};
```
그러면 땃쥐가 파래집니다.
| | |
|---|---|
|<img width="262" height="520" alt="스크린샷 2025-09-16 15 34 04" src="https://github.com/user-attachments/assets/0f08d834-3425-4082-9fb9-ee5fe27cd48a" />|<img width="265" height="546" alt="스크린샷 2025-09-16 22 38 41" src="https://github.com/user-attachments/assets/b90abcd9-3d9c-4201-a1c8-d327adbd4b3f" />|

근데 땃쥐에 투시가 더 많이 들어간 것 같죠?
왜냐하면 터치 입력을 받아 뷰 회전하는 기능을 추가하면서 행렬 계산이 약간 바뀌었기 때문입니다. 

UIRepresentable만으로는 터치 입력을 받지 못합니다. 그래서 UIKit 뷰 서브클래스를 만들어서 수정한 후 Swift로 래핑된 뷰와 연결해주어야 합니다.

```
struct metalView: UIViewRepresentable {

    func makeCoordinator() -> Coordinator {...}
    
    func makeUIView(context: Context) -> MTKView {
        let mtkView = TouchMTKView()
        mtkView.device = MTLCreateSystemDefaultDevice()
        mtkView.clearColor = Colors.wenderlichGreen

        let delegate = MetalViewDelegate(metalView: mtkView)
        mtkView.delegate = delegate
        mtkView.touchProxy = delegate
        
        context.coordinator.delegate = delegate
        return mtkView
    }
    
    func updateUIView(_ uiView: MTKView, context: Context) {...}
    
    class Coordinator {...}
}

class TouchMTKView: MTKView {
    weak var touchProxy: MetalViewDelegate?
    
    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {...}
    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {...}
    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {...}
    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {...}
}
```
MTKView에서 덮어씌운 함수는 Delegate 내에 별도로 선언해주어야 합니다.

```
class MetalViewDelegate : NSObject, MTKViewDelegate { 
     ...
     private var yaw: Float = 0
    private var pitch: Float = 0
    private var previousTouch: CGPoint = .zero
    private let sensitivity: Float = 0.01
    ...

    func handleTouchesBegan(_ touches: Set<UITouch>, in view: UIView) {
            guard let t = touches.first else { return }
            previousTouch = t.location(in: view)
        }
        func handleTouchesMoved(_ touches: Set<UITouch>, in view: UIView) {
            guard let t = touches.first else { return }
            let loc = t.location(in: view)
            let dx = Float(previousTouch.x - loc.x)
            let dy = Float(previousTouch.y - loc.y)
        
            pitch += dy * sensitivity
            yaw += dx * sensitivity
        
            previousTouch = loc
        }
        func handleTouchesEnded(_ touches: Set<UITouch>, in view: UIView) {}
        func handleTouchesCancelled(_ touches: Set<UITouch>, in view: UIView) {}

    ...

    func draw(in view: MTKView) {
       ...
        
        let modelScene = InstanceScene(device: device, view: view, rotation: SIMD2<Float>(yaw, pitch))

        ...
        commandBuffer.commit()
    }
}
```
이전 터치 좌표와 현재 터치 좌표를 각각 저장하고, 이 둘의 차이를 계산합니다. 그리고 InstanceScene에 넘겨줍니다.

```
class InstanceScene: Renderer { 
    ...
     var rotation: SIMD2<Float>
      ...

     init(device: MTLDevice, view: MTKView, rotation: SIMD2<Float>) {
        self.device = device
        self.view = view
        self.rotation = rotation
     ...
     }
     ...
      func render(commandEncoder: MTLRenderCommandEncoder) {
              guard let objShader = self.objShader else { return }
              commandEncoder.setRenderPipelineState(objShader)
        
              var sceneConstants = SceneConstants()
             let aspect = Float(view.drawableSize.width / view.drawableSize.height)
             let sceneProjectionMatrix = matrix_float4x4(fovY: radians(degrees:65), aspect: aspect, near: 0.1, far: 100)
        
             let rotX = matrix_float4x4(rotationAngle: rotation.y, x: 1, y: 0, z: 0)
             let rotY = matrix_float4x4(rotationAngle: rotation.x, x: 0, y: 1, z: 0)
        
             let sceneTranslationMatrix = matrix_float4x4(translationX: 0, y: -1, z: -5)
        
            let modelMatrix = matrix_multiply(rotY, rotX)
            let modelViewMatrix = matrix_multiply(sceneTranslationMatrix, modelMatrix)
        
           let sceneViewMatrix = matrix_multiply(sceneProjectionMatrix, modelViewMatrix)
           sceneConstants.sceneViewMatrix = sceneViewMatrix

       ...
      }
}
```
마지막으로 받아온 rotation값을 sceneConstants의 회전 계산에 추가해주면 됩니다. 
그러면 월드 원점 기준으로 뷰가 회전합니다다.

https://github.com/user-attachments/assets/b12ca19f-1a42-4452-a48e-ba88927d878b

